### PR TITLE
Sensors: Remove Unused Scaling Factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ The sensors (which are written to the `*.hdf5` file when used) are defined as:
   offset: -125.0
   phys_max: 100.0
   phys_min: -100.0
-  scaling_factor: 75.75757575757575
   sensor_id: acc100g_01
   sensor_type: ADXL1001
   unit: g

--- a/icoapi/config/sensors.yaml
+++ b/icoapi/config/sensors.yaml
@@ -9,7 +9,6 @@ sensors:
   offset: -125.0
   phys_max: 100.0
   phys_min: -100.0
-  scaling_factor: 75.75757575757575
   sensor_id: acc100g_01
   sensor_type: ADXL1001
   unit: g
@@ -20,7 +19,6 @@ sensors:
   offset: -45.000000000000014
   phys_max: 40.0
   phys_min: -40.0
-  scaling_factor: 50.00000000000001
   sensor_id: acc40g_y
   sensor_type: ADXL358C
   unit: g
@@ -31,7 +29,6 @@ sensors:
   offset: -45.000000000000014
   phys_max: 40.0
   phys_min: -40.0
-  scaling_factor: 50.00000000000001
   sensor_id: acc40g_z
   sensor_type: ADXL358C
   unit: g
@@ -42,7 +39,6 @@ sensors:
   offset: -45.000000000000014
   phys_max: 40.0
   phys_min: -40.0
-  scaling_factor: 50.00000000000001
   sensor_id: acc40g_x
   sensor_type: ADXL358C
   unit: g
@@ -53,7 +49,6 @@ sensors:
   offset: -297.3333333333334
   phys_max: 125.0
   phys_min: -40.0
-  scaling_factor: 333.3333333333334
   sensor_id: temp_01
   sensor_type: ADXL358C
   unit: "\xB0C"
@@ -64,7 +59,6 @@ sensors:
   offset: 0.0
   phys_max: 1.0
   phys_min: 0.0
-  scaling_factor: 0.30303030303030304
   sensor_id: photo_01
   sensor_type: null
   unit: '-'
@@ -75,7 +69,6 @@ sensors:
   offset: 0.0
   phys_max: 1.0
   phys_min: 0.0
-  scaling_factor: 0.30303030303030304
   sensor_id: backpack_01
   sensor_type: null
   unit: /
@@ -86,7 +79,6 @@ sensors:
   offset: 0.0
   phys_max: 1.0
   phys_min: 0.0
-  scaling_factor: 0.30303030303030304
   sensor_id: backpack_02
   sensor_type: null
   unit: /
@@ -97,7 +89,6 @@ sensors:
   offset: 0.0
   phys_max: 1.0
   phys_min: 0.0
-  scaling_factor: 0.30303030303030304
   sensor_id: backpack_03
   sensor_type: null
   unit: /
@@ -108,7 +99,6 @@ sensors:
   offset: -0.0021929824561413014
   phys_max: 4.2
   phys_min: 2.9
-  scaling_factor: 5.701754385964914
   sensor_id: vbat_01
   sensor_type: null
   unit: V
@@ -119,7 +109,6 @@ sensors:
   offset: -98100.000
   phys_max: 78480.0
   phys_min: -78480.0
-  scaling_factor: 59454.54545
   sensor_id: rotacc_01
   sensor_type: 2xADXL1001
   unit: 1/s^2
@@ -130,7 +119,6 @@ sensors:
   offset: -77122.642
   phys_max: 61698.11321
   phys_min: -61698.11321
-  scaling_factor: 46740.99485
   sensor_id: rotacc_02
   sensor_type: 2xADXL1001
   unit: 1/s^2

--- a/icoapi/scripts/data_handling.py
+++ b/icoapi/scripts/data_handling.py
@@ -290,10 +290,9 @@ def find_sensor_by_id(
     for sensor in sensors:
         if sensor.sensor_id == sensor_id:
             logger.debug(
-                "Found sensor with ID %s: %s | k2: %s | d2: %s",
+                "Found sensor with ID %s: %s | d2: %s",
                 sensor.sensor_id,
                 sensor.name,
-                sensor.scaling_factor,
                 sensor.offset,
             )
             return sensor
@@ -328,10 +327,9 @@ def get_sensor_for_channel(
     if channel_instruction.channel_number in range(1, 11):
         sensor = sensors[channel_instruction.channel_number - 1]
         logger.info(
-            "Default sensor for channel %s: %s | k2: %s | d2: %s",
+            "Default sensor for channel %s: %s | d2: %s",
             channel_instruction.channel_number,
             sensor.name,
-            sensor.scaling_factor,
             sensor.offset,
         )
         return sensor
@@ -374,7 +372,6 @@ class SensorDescription(IsDescription):
     phys_max = Float32Col()  # Float for physical maximum
     volt_min = Float32Col()  # Float for voltage minimum
     volt_max = Float32Col()  # Float for voltage maximum
-    scaling_factor = Float32Col()  # Float for scaling factor
     offset = Float32Col()  # Float for offset
 
 
@@ -410,7 +407,6 @@ def add_sensor_data_to_storage(
         row["phys_max"] = sensor.phys_max
         row["volt_min"] = sensor.volt_min
         row["volt_max"] = sensor.volt_max
-        row["scaling_factor"] = sensor.scaling_factor
         row["offset"] = sensor.offset
         row.append()
         count += 1


### PR DESCRIPTION
# Description

As far as I can tell, the scaling factor is currently calculated here:

https://github.com/MyTooliT/ICOapi/blob/fa8f1621e478db07b2c00e84ba040e9bcfb4bf86/icoapi/models/models.py#L371-L385

The constant scaling factor in the configuration file might be an artifact from an older version of the code. Since I am not sure about that I opened this PR. Can you please take a look Moritz?