### PR TITLE
Models: Limit Measurement Value to Min/Max Value

### DIFF
--- a/icoapi/models/models.py
+++ b/icoapi/models/models.py
@@ -387,7 +387,17 @@ class Sensor(BaseModel):
     def convert_to_phys(self, volt_value: float) -> float:
         """Convert voltage to physical value"""
 
-        return volt_value * self.scaling_factor + self.offset
+        physical_value = volt_value * self.scaling_factor + self.offset
+
+        phys_min = self.phys_min
+        phys_max = self.phys_max
+
+        if physical_value <= phys_min:
+            physical_value = phys_min
+        elif physical_value >= phys_max:
+            physical_value = phys_max
+
+        return physical_value
 
 
 @dataclass


### PR DESCRIPTION
# Description

While testing I noticed that for 

- an ADC channel that returns very low 16 bit values, and
- a sensor with the sensor id [`acc100g_01`](https://github.com/MyTooliT/ICOapi/blob/fa8f1621e478db07b2c00e84ba040e9bcfb4bf86/icoapi/config/sensors.yaml#L8-L18)

the API was returning **values below -100g**. I assume the reason behind this is the offset value of `125.0`. If the offset is correct, then I still think **values below the minimum or above the physical max value are quite unexpected**. This is why I opened this pull request. Can you please take a look at the changes Moritz and maybe explain why the current offset is `125` and not `100`?