### PR TITLE
Return supply voltage on STH connect

### DIFF
--- a/icoapi/models/models.py
+++ b/icoapi/models/models.py
@@ -1,12 +1,12 @@
 """Data Model Information"""
-
+import datetime
 from enum import unique, StrEnum
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from json import JSONEncoder
 from typing import Any, Dict, List, Optional
 
 import pandas
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from icostate import ADCConfiguration, SensorNodeInfo
 
@@ -532,6 +532,29 @@ class ConfigRestoreRequest(BaseModel):
 
     filename: str
     backup_filename: str
+
+
+def _require_all_fields(schema: dict[str, Any]) -> None:
+    schema["required"] = list(schema.get("properties", {}).keys())
+
+
+@dataclass
+class SupplyVoltageResponseModel:
+    """
+    Response model for supply voltage
+
+    Use the indication field when a mapping of the voltage to a specific
+    charge status becomes available.
+    """
+
+    __pydantic_config__ = ConfigDict(json_schema_extra=_require_all_fields)
+
+    supply_voltage: float
+    unit: str = "V"
+    indication: str | None = None
+    timestamp_utc_iso: str = field(
+        default_factory=lambda: datetime.datetime.now(datetime.UTC).isoformat()
+    )
 
 
 if __name__ == "__main__":

--- a/icoapi/routers/sth_routes.py
+++ b/icoapi/routers/sth_routes.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Body, Depends
 from icotronic.can.error import NoResponseError
 from icostate import ICOsystem
 from icostate.error import IncorrectStateError
+import logging
 
 from icoapi.scripts.errors import (
     HTTP_400_INCORRECT_STATE_EXCEPTION,
@@ -29,6 +30,8 @@ from icoapi.scripts.sth_scripts import (
     rename_sth_device,
     write_sth_adc,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/sth",
@@ -127,18 +130,27 @@ async def sth(
 async def sth_connect(
     mac_address: Annotated[str, Body(embed=True)],
     system: ICOsystem = Depends(get_system),
-) -> None:
-    """Connect to sensor node"""
+) -> float | None:
+    """Connect to sensor node and return the supply voltage"""
 
     try:
         await connect_sth_device_by_mac(system, mac_address)
-        return None
     except IncorrectStateError as error:
         raise HTTP_400_INCORRECT_STATE_EXCEPTION from error
     except TimeoutError as error:
         raise HTTP_404_STH_UNREACHABLE_EXCEPTION from error
     except NoResponseError as error:
         raise HTTP_502_CAN_NO_RESPONSE_EXCEPTION from error
+
+
+    if system.sensor_node is not None:
+        supply_voltage: float = await system.sensor_node.get_supply_voltage()
+        formatted_supply_voltage = round(supply_voltage, 2)
+        logger.info("Connected STH has supply voltage: %sV", formatted_supply_voltage)
+        return supply_voltage
+
+    logger.warning("Could not get supply voltage from connected STH.")
+    return None
 
 
 @router.put(

--- a/icoapi/routers/sth_routes.py
+++ b/icoapi/routers/sth_routes.py
@@ -12,14 +12,14 @@ from icoapi.scripts.errors import (
     HTTP_400_INCORRECT_STATE_SPEC,
     HTTP_404_STH_UNREACHABLE_EXCEPTION,
     HTTP_404_STH_UNREACHABLE_SPEC,
-    HTTP_502_CAN_NO_RESPONSE_SPEC,
+    HTTP_500_SUPPLY_VOLTAGE_EXCEPTION, HTTP_500_SUPPLY_VOLTAGE_SPEC, HTTP_502_CAN_NO_RESPONSE_SPEC,
     HTTP_502_CAN_NO_RESPONSE_EXCEPTION,
 )
 from icoapi.models.models import (
     ADCValues,
     STHDeviceResponseModel,
     STHRenameRequestModel,
-    STHRenameResponseModel,
+    STHRenameResponseModel, SupplyVoltageResponseModel,
 )
 from icoapi.models.globals import get_system
 from icoapi.scripts.sth_scripts import (
@@ -130,8 +130,8 @@ async def sth(
 async def sth_connect(
     mac_address: Annotated[str, Body(embed=True)],
     system: ICOsystem = Depends(get_system),
-) -> float | None:
-    """Connect to sensor node and return the supply voltage"""
+) -> None:
+    """Connect to sensor node"""
 
     try:
         await connect_sth_device_by_mac(system, mac_address)
@@ -141,15 +141,6 @@ async def sth_connect(
         raise HTTP_404_STH_UNREACHABLE_EXCEPTION from error
     except NoResponseError as error:
         raise HTTP_502_CAN_NO_RESPONSE_EXCEPTION from error
-
-    if system.sensor_node is not None:
-        supply_voltage: float = await system.sensor_node.get_supply_voltage()
-        formatted_supply_voltage = round(supply_voltage, 2)
-        logger.info("Connected STH has supply voltage: %sV", formatted_supply_voltage)
-        return supply_voltage
-
-    logger.warning("Could not get supply voltage from connected STH.")
-    return None
 
 
 @router.put(
@@ -278,3 +269,23 @@ async def write_adc(
         raise HTTP_404_STH_UNREACHABLE_EXCEPTION from error
     except NoResponseError as error:
         raise HTTP_502_CAN_NO_RESPONSE_EXCEPTION from error
+
+
+@router.get(
+    "/supply-voltage",
+    responses={
+        200: {"description": "Supply voltage of connected STH."},
+        500: HTTP_500_SUPPLY_VOLTAGE_SPEC,
+    }
+)
+async def get_supply_voltage(system: ICOsystem = Depends(get_system)) -> SupplyVoltageResponseModel:
+    """Get supply voltage of connected STH."""
+    try:
+        supply_voltage: float = await system.sensor_node.get_supply_voltage()
+        formatted_supply_voltage = round(supply_voltage, 2)
+        logger.info("Connected STH supply voltage: %sV", formatted_supply_voltage)
+        return SupplyVoltageResponseModel(supply_voltage=supply_voltage)
+
+    except AttributeError as error:
+        logger.error("Could not get supply voltage from connected STH: %s", str(error))
+        raise HTTP_500_SUPPLY_VOLTAGE_EXCEPTION(str(error)) from error

--- a/icoapi/routers/sth_routes.py
+++ b/icoapi/routers/sth_routes.py
@@ -1,11 +1,11 @@
 """Routes for STH functionality"""
 
+import logging
 from typing import Annotated
 from fastapi import APIRouter, Body, Depends
 from icotronic.can.error import NoResponseError
 from icostate import ICOsystem
 from icostate.error import IncorrectStateError
-import logging
 
 from icoapi.scripts.errors import (
     HTTP_400_INCORRECT_STATE_EXCEPTION,
@@ -141,7 +141,6 @@ async def sth_connect(
         raise HTTP_404_STH_UNREACHABLE_EXCEPTION from error
     except NoResponseError as error:
         raise HTTP_502_CAN_NO_RESPONSE_EXCEPTION from error
-
 
     if system.sensor_node is not None:
         supply_voltage: float = await system.sensor_node.get_supply_voltage()

--- a/icoapi/scripts/errors.py
+++ b/icoapi/scripts/errors.py
@@ -477,3 +477,32 @@ HTTP_500_CLOUD_UPLOAD_PRESIGN_SPEC = {
         }
     },
 }
+
+
+class HTTP_500_SUPPLY_VOLTAGE_EXCEPTION(HTTPException):  # pylint: disable=invalid-name
+    """Failed to read supply voltage."""
+    def __init__(self, e: str):
+        super().__init__(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to read supply voltage. {e}",
+        )
+
+
+HTTP_500_SUPPLY_VOLTAGE_SPEC = {
+    "description": "Failed to read supply voltage.",
+    "content": {
+        "application/json": {
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "detail": {"type": "string"},
+                    "status_code": {"type": "integer"},
+                },
+            },
+            "example": {
+                "detail": "Failed to read supply voltage.",
+                "status_code": 500,
+            }
+        }
+    }
+}


### PR DESCRIPTION
This makes the sth/connect request return the STH's supply voltage. The feature was requested by users of ICOc who rely on this to check on the STH's battery charge. This is not currently implemented in ICOn despite being in ICOc.

@sanssecours what are your thoughts on implementing this here?
I also thought about putting it in a lower-level library like ICOstate, but for now, this seems to work.