### PR TITLE
Logging: Use UTF-8 Encoding for Log Files

### DIFF
--- a/icoapi/utils/logging_setup.py
+++ b/icoapi/utils/logging_setup.py
@@ -111,7 +111,10 @@ def setup_logging() -> None:
         )
 
     file_handler = RotatingFileHandler(
-        LOG_PATH, maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUP_COUNT
+        LOG_PATH,
+        maxBytes=LOG_MAX_BYTES,
+        backupCount=LOG_BACKUP_COUNT,
+        encoding="utf-8",
     )
     file_handler.setFormatter(formatter)
 


### PR DESCRIPTION
As far as I can tell this should [fix issue #41 of the ICOtronic library](https://github.com/MyTooliT/ICOtronic/issues/41). I tested this on my Windows machine, where I was able to reproduce the problem. After the update the standard (error/output) log did not contain any logging errors anymore.